### PR TITLE
Fix localization language selection: Use navigator for client-only config

### DIFF
--- a/ui/src/utils/i18n.ts
+++ b/ui/src/utils/i18n.ts
@@ -74,9 +74,6 @@ void i18n
     // Always enable debug mode to see what's happening
     debug: true,
 
-    // Default language
-    lng: 'en',
-
     // Fallback language
     fallbackLng: 'en',
 
@@ -91,6 +88,14 @@ void i18n
     saveMissing: true,
     missingKeyHandler: (lng, ns, key) => {
       console.log(`Missing translation: [${lng}] ${ns}:${key}`)
+    },
+
+    // Language detection configuration
+    detection: {
+      // Order of detection methods
+      order: ['navigator', 'htmlTag', 'path', 'subdomain'],
+      // Don't cache detected language
+      caches: []
     },
 
     // Backend configuration


### PR DESCRIPTION
Fixes issue in which translations are not applied despite having browser in separate language setting. Since we are a local client-only application, we should use the navigator language rather than the htmlTag or subdomain.